### PR TITLE
Add allow-empty-zones setting support for views.

### DIFF
--- a/manifests/view.pp
+++ b/manifests/view.pp
@@ -9,6 +9,7 @@ define bind::view (
     $recursion_match_clients      = 'any',
     $recursion_match_destinations = '',
     $recursion_match_only         = false,
+    $empty_zones                  = '',
     $notify_source                = '',
     $also_notify                  = [],
     $order                        = '10',

--- a/templates/view.erb
+++ b/templates/view.erb
@@ -34,6 +34,9 @@ view "<%= @name %>" {
 	};
 <%-   end -%>
 <%- end -%>
+<%- if @empty_zones and @empty_zones != '' -%>
+	empty-zones-enable <%= @empty_zones ? 'yes' : 'no' %>;
+<%- end -%>
 <%- if @also_notify and @also_notify != '' -%>
 	also-notify {
 <%-     Array(@also_notify).each do |server| -%>


### PR DESCRIPTION
See: https://deepthought.isc.org/article/AA-00800/0/Automatic-empty-zones-including-RFC-1918-prefixes.html

Defaults to unspecified, as Bind's behaviour differs depending on (minor!) version, and whether recursion is enabled on a view.